### PR TITLE
Init hci_uart_cb, otherwise strange behavior after powercycle

### DIFF
--- a/Middlewares/Third_Party/btstack-integration/COMPONENT_HCI-UART/freertos/cybt_platform_freertos.c
+++ b/Middlewares/Third_Party/btstack-integration/COMPONENT_HCI-UART/freertos/cybt_platform_freertos.c
@@ -170,7 +170,8 @@ void cybt_platform_init(void)
                       );
     MAIN_TRACE_DEBUG("cybt_platform_init(): platform_sleep_idle_timer = 0x%x", &platform_sleep_idle_timer);
 #endif
-
+    memset(&hci_uart_cb, 0, sizeof(hci_uart_cb_t));
+    
     cyhal_lptimer_init(&bt_stack_lptimer);
     cyhal_lptimer_enable_event(&bt_stack_lptimer,
                                CYHAL_LPTIMER_COMPARE_MATCH,


### PR DESCRIPTION
Description
Proper initialization of hci_uart_cb

Related Issue
If the struct is not initialized, the BT module will not be initialized after a power cycle, and then the module does not get the configuration.
It looks that the SRAM from the STMU5 is keeping the hci_uart_cb.inited bool. The execution/initialization fails then in the "if(true == hci_uart_cb.inited)" in the function "cybt_result_t cybt_platform_hci_open(void *p_arg)".