### PR TITLE
Add Support for STM32H7RSxx Family

### DIFF
--- a/Middlewares/Third_Party/pal/targets/TARGET_STM32/Inc/stm32_cyhal_common.h
+++ b/Middlewares/Third_Party/pal/targets/TARGET_STM32/Inc/stm32_cyhal_common.h
@@ -57,6 +57,8 @@
     #define TARGET_STM32U5xx
 #elif defined (STM32H563xx)
     #define TARGET_STM32H5xx
+#elif defined (STM32H7S7xx)
+    #define TARGET_STM32H7RSxx
 #else
     #error "Selected STM32 device is not supported by this package."
 #endif
@@ -76,6 +78,9 @@
     #include "stm32h5xx.h"
     #include "stm32h5xx_hal.h"
     #include "stm32h5xx_hal_def.h"
+#elif defined (TARGET_STM32H7RSxx)
+    #include "stm32h7rsxx.h"
+    #include "stm32h7rsxx_hal.h"
 #else
     #error "Selected STM32 device is not supported by this package."
 #endif
@@ -89,9 +94,7 @@
 #endif /* defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U) */
 
 /* Macro to ALIGN */
-#if defined (__ARMCC_VERSION) /* ARM Compiler */
-    #define ALIGN_HAL_COMMON(buf, x) __align(x) buf
-#elif defined   (__GNUC__)    /* GNU Compiler */
+#if defined (__ARMCC_VERSION) /* ARM Compiler */ || defined   (__GNUC__)    /* GNU Compiler */
     #define ALIGN_HAL_COMMON(buf, x)  buf __attribute__ ((aligned (x)))
 #elif defined (__ICCARM__)    /* IAR Compiler */
     #define ALIGN_HAL_COMMON(buf, x) __ALIGNED(x) buf

--- a/Middlewares/Third_Party/pal/targets/TARGET_STM32/Inc/stm32_cyhal_gpio_pin.h
+++ b/Middlewares/Third_Party/pal/targets/TARGET_STM32/Inc/stm32_cyhal_gpio_pin.h
@@ -252,6 +252,78 @@ extern "C" {
     #define PK14        (CYHAL_GET_GPIO(GPIOK, GPIO_PIN_14)) //!< Port K Pin 14
     #define PK15        (CYHAL_GET_GPIO(GPIOK, GPIO_PIN_15)) //!< Port K Pin 15
 #endif // if defined(GPIOK)
+#if defined(GPIOM)
+    #define PM0         (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_0))  //!< Port M Pin 0
+    #define PM1         (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_1))  //!< Port M Pin 1
+    #define PM2         (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_2))  //!< Port M Pin 2
+    #define PM3         (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_3))  //!< Port M Pin 3
+    #define PM4         (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_4))  //!< Port M Pin 4
+    #define PM5         (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_5))  //!< Port M Pin 5
+    #define PM6         (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_6))  //!< Port M Pin 6
+    #define PM7         (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_7))  //!< Port M Pin 7
+    #define PM8         (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_8))  //!< Port M Pin 8
+    #define PM9         (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_9))  //!< Port M Pin 9
+    #define PM10        (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_10)) //!< Port M Pin 10
+    #define PM11        (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_11)) //!< Port M Pin 11
+    #define PM12        (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_12)) //!< Port M Pin 12
+    #define PM13        (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_13)) //!< Port M Pin 13
+    #define PM14        (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_14)) //!< Port M Pin 14
+    #define PM15        (CYHAL_GET_GPIO(GPIOM, GPIO_PIN_15)) //!< Port M Pin 15
+#endif // if defined(GPIOM)
+#if defined(GPION)
+    #define PN0         (CYHAL_GET_GPIO(GPION, GPIO_PIN_0))  //!< Port N Pin 0
+    #define PN1         (CYHAL_GET_GPIO(GPION, GPIO_PIN_1))  //!< Port N Pin 1
+    #define PN2         (CYHAL_GET_GPIO(GPION, GPIO_PIN_2))  //!< Port N Pin 2
+    #define PN3         (CYHAL_GET_GPIO(GPION, GPIO_PIN_3))  //!< Port N Pin 3
+    #define PN4         (CYHAL_GET_GPIO(GPION, GPIO_PIN_4))  //!< Port N Pin 4
+    #define PN5         (CYHAL_GET_GPIO(GPION, GPIO_PIN_5))  //!< Port N Pin 5
+    #define PN6         (CYHAL_GET_GPIO(GPION, GPIO_PIN_6))  //!< Port N Pin 6
+    #define PN7         (CYHAL_GET_GPIO(GPION, GPIO_PIN_7))  //!< Port N Pin 7
+    #define PN8         (CYHAL_GET_GPIO(GPION, GPIO_PIN_8))  //!< Port N Pin 8
+    #define PN9         (CYHAL_GET_GPIO(GPION, GPIO_PIN_9))  //!< Port N Pin 9
+    #define PN10        (CYHAL_GET_GPIO(GPION, GPIO_PIN_10)) //!< Port N Pin 10
+    #define PN11        (CYHAL_GET_GPIO(GPION, GPIO_PIN_11)) //!< Port N Pin 11
+    #define PN12        (CYHAL_GET_GPIO(GPION, GPIO_PIN_12)) //!< Port N Pin 12
+    #define PN13        (CYHAL_GET_GPIO(GPION, GPIO_PIN_13)) //!< Port N Pin 13
+    #define PN14        (CYHAL_GET_GPIO(GPION, GPIO_PIN_14)) //!< Port N Pin 14
+    #define PN15        (CYHAL_GET_GPIO(GPION, GPIO_PIN_15)) //!< Port N Pin 15
+#endif // if defined(GPION)
+#if defined(GPIOO)
+    #define PO0         (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_0))  //!< Port O Pin 0
+    #define PO1         (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_1))  //!< Port O Pin 1
+    #define PO2         (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_2))  //!< Port O Pin 2
+    #define PO3         (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_3))  //!< Port O Pin 3
+    #define PO4         (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_4))  //!< Port O Pin 4
+    #define PO5         (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_5))  //!< Port O Pin 5
+    #define PO6         (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_6))  //!< Port O Pin 6
+    #define PO7         (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_7))  //!< Port O Pin 7
+    #define PO8         (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_8))  //!< Port O Pin 8
+    #define PO9         (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_9))  //!< Port O Pin 9
+    #define PO10        (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_10)) //!< Port O Pin 10
+    #define PO11        (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_11)) //!< Port O Pin 11
+    #define PO12        (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_12)) //!< Port O Pin 12
+    #define PO13        (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_13)) //!< Port O Pin 13
+    #define PO14        (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_14)) //!< Port O Pin 14
+    #define PO15        (CYHAL_GET_GPIO(GPIOO, GPIO_PIN_15)) //!< Port O Pin 15
+#endif // if defined(GPIOO)
+#if defined(GPIOP)
+    #define PP0         (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_0))  //!< Port P Pin 0
+    #define PP1         (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_1))  //!< Port P Pin 1
+    #define PP2         (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_2))  //!< Port P Pin 2
+    #define PP3         (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_3))  //!< Port P Pin 3
+    #define PP4         (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_4))  //!< Port P Pin 4
+    #define PP5         (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_5))  //!< Port P Pin 5
+    #define PP6         (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_6))  //!< Port P Pin 6
+    #define PP7         (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_7))  //!< Port P Pin 7
+    #define PP8         (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_8))  //!< Port P Pin 8
+    #define PP9         (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_9))  //!< Port P Pin 9
+    #define PP10        (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_10)) //!< Port P Pin 10
+    #define PP11        (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_11)) //!< Port P Pin 11
+    #define PP12        (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_12)) //!< Port P Pin 12
+    #define PP13        (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_13)) //!< Port P Pin 13
+    #define PP14        (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_14)) //!< Port P Pin 14
+    #define PP15        (CYHAL_GET_GPIO(GPIOP, GPIO_PIN_15)) //!< Port P Pin 15
+#endif // if defined(GPIOP)
 
 typedef uint32_t cyhal_gpio_def_t;
 

--- a/Middlewares/Third_Party/pal/targets/TARGET_STM32/Inc/stm32_cyhal_sdio_ex.h
+++ b/Middlewares/Third_Party/pal/targets/TARGET_STM32/Inc/stm32_cyhal_sdio_ex.h
@@ -64,6 +64,9 @@ extern "C" {
 #elif defined (TARGET_STM32H5xx)
 /* RCC clock for SDMMC */
   #define STM32_RCC_PERIPHCLK_SDMMC RCC_PERIPHCLK_SDMMC1
+/* RCC clock for SDMMC */
+#elif defined (TARGET_STM32H7RSxx)
+  #define STM32_RCC_PERIPHCLK_SDMMC RCC_PERIPHCLK_SDMMC12
 #endif // if defined (TARGET_STM32H7xx)
 
 

--- a/Middlewares/Third_Party/pal/targets/TARGET_STM32/Src/stm32_cyhal_gpio.c
+++ b/Middlewares/Third_Party/pal/targets/TARGET_STM32/Src/stm32_cyhal_gpio.c
@@ -122,6 +122,30 @@ extern "C" {
     #define PORT_GPIOK NULL
 #endif /* defined(GPIOK) */
 
+#if defined(GPIOM)
+    #define PORT_GPIOM GPIOM
+#else
+    #define PORT_GPIOM NULL
+#endif /* defined(GPIOM) */
+
+#if defined(GPION)
+    #define PORT_GPION GPION
+#else
+    #define PORT_GPION NULL
+#endif /* defined(GPION) */
+
+#if defined(GPIOO)
+    #define PORT_GPIOO GPIOO
+#else
+    #define PORT_GPIOO NULL
+#endif /* defined(GPIOO) */
+
+#if defined(GPIOP)
+    #define PORT_GPIOP GPIOP
+#else
+    #define PORT_GPIOP NULL
+#endif /* defined(GPIOP) */
+
 #define CYHAL_MAX_EXTI_NUMBER       (16U)
 
 /* Return pin number by counts the number of leading zeros of a data value.
@@ -657,7 +681,7 @@ static void _stm32_cyhal_gpio_enable_irq(uint32_t pin_number, uint32_t priority,
         EXTI15_10_IRQn, /* IRQ for EXTI line 14 */
         EXTI15_10_IRQn, /* IRQ for EXTI line 15 */
     };
-    #elif defined (TARGET_STM32L5xx) || defined (TARGET_STM32U5xx)
+    #elif defined (TARGET_STM32L5xx) || defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx)
     const IRQn_Type exti_table[] =
     {
         EXTI0_IRQn,  /* IRQ for EXTI line 0 */
@@ -670,26 +694,6 @@ static void _stm32_cyhal_gpio_enable_irq(uint32_t pin_number, uint32_t priority,
         EXTI7_IRQn,  /* IRQ for EXTI line 7 */
         EXTI8_IRQn,  /* IRQ for EXTI line 8 */
         EXTI9_IRQn,  /* IRQ for EXTI line 9 */
-        EXTI10_IRQn, /* IRQ for EXTI line 10 */
-        EXTI11_IRQn, /* IRQ for EXTI line 11 */
-        EXTI12_IRQn, /* IRQ for EXTI line 12 */
-        EXTI13_IRQn, /* IRQ for EXTI line 13 */
-        EXTI14_IRQn, /* IRQ for EXTI line 14 */
-        EXTI15_IRQn, /* IRQ for EXTI line 15 */
-    };
-    #elif defined (TARGET_STM32H5xx)
-    const IRQn_Type exti_table[] =
-    {
-        EXTI0_IRQn, /* IRQ for EXTI line 0 */
-        EXTI1_IRQn, /* IRQ for EXTI line 1 */
-        EXTI2_IRQn, /* IRQ for EXTI line 2 */
-        EXTI3_IRQn, /* IRQ for EXTI line 3 */
-        EXTI4_IRQn, /* IRQ for EXTI line 4 */
-        EXTI5_IRQn, /* IRQ for EXTI line 5 */
-        EXTI6_IRQn, /* IRQ for EXTI line 6 */
-        EXTI7_IRQn, /* IRQ for EXTI line 7 */
-        EXTI8_IRQn, /* IRQ for EXTI line 8 */
-        EXTI9_IRQn, /* IRQ for EXTI line 9 */
         EXTI10_IRQn, /* IRQ for EXTI line 10 */
         EXTI11_IRQn, /* IRQ for EXTI line 11 */
         EXTI12_IRQn, /* IRQ for EXTI line 12 */

--- a/Middlewares/Third_Party/pal/targets/TARGET_STM32/Src/stm32_cyhal_lptimer.c
+++ b/Middlewares/Third_Party/pal/targets/TARGET_STM32/Src/stm32_cyhal_lptimer.c
@@ -71,14 +71,14 @@ extern "C" {
 #endif
 
 
-#if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx)
+#if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx)
     #define _CYHAL_LPTIM_FLAG_DIEROK    LPTIM_FLAG_DIEROK
     #define _CYHAL_LPTIM_FLAG_CMPOK     LPTIM_FLAG_CMP1OK
     #define _CYHAL_LPTIM_IER_ARRMIE     LPTIM_DIER_ARRMIE
 #else
     #define _CYHAL_LPTIM_FLAG_CMPOK     LPTIM_FLAG_CMPOK
     #define _CYHAL_LPTIM_IER_ARRMIE     LPTIM_IER_ARRMIE
-#endif /* defined (TARGET_STM32U5xx) */
+#endif /* defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx) */
 
 /* The datasheet states: ARR is the autoreload value for the LPTIM. This value
  * must be strictly greater than the CMP[15:0] value.  Since ARR is being set
@@ -265,11 +265,11 @@ static void _cyhal_lptimer_handle_match(cyhal_lptimer_t* obj)
         __HAL_LPTIM_CLEAR_FLAG(obj->hlptimer, _CYHAL_LPTIM_FLAG_CMPOK);
 
         /* Load the Timeout value in the compare register */
-        #if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx)
+        #if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx)
         __HAL_LPTIM_COMPARE_SET(obj->hlptimer, LPTIM_CHANNEL_1, cmp_val);
         #else
         __HAL_LPTIM_COMPARE_SET(obj->hlptimer, cmp_val);
-        #endif /* defined (TARGET_STM32U5xx) */
+        #endif /* defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx) */
 
         /* Wait for the completion of the write operation to the LPTIM_CMP register */
         while (!__HAL_LPTIM_GET_FLAG(obj->hlptimer, _CYHAL_LPTIM_FLAG_CMPOK))
@@ -415,11 +415,11 @@ cy_rslt_t cyhal_lptimer_init(cyhal_lptimer_t* obj)
          *
          * LPTIMER IRQs are NOT enabled here
          */
-        #if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx)
+        #if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx)
         /* For STM32U5 a period of Autoreload register (ARR) configure in
          * HAL_LPTIM_Init by using hlptimer->Init.Period value */
         obj->hlptimer->Init.Period = _CYHAL_LPTIMER_MAX_PERIOD;
-        #endif /* defined (TARGET_STM32U5xx) */
+        #endif /* defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx) */
 
         if (HAL_LPTIM_Init(obj->hlptimer) != HAL_OK)
         {
@@ -441,14 +441,14 @@ cy_rslt_t cyhal_lptimer_init(cyhal_lptimer_t* obj)
             HAL_StatusTypeDef hal_ret;
             /* Set ARR to MAX(16bit) */
             /* Set CMP to MAX(16bit) */
-            #if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx)
+            #if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx)
             hal_ret = HAL_LPTIM_TimeOut_Start_IT(obj->hlptimer,
                                                  _CYHAL_LPTIMER_MAX_COMPARE);
             #else
             hal_ret = HAL_LPTIM_TimeOut_Start_IT(obj->hlptimer,
                                                  _CYHAL_LPTIMER_MAX_PERIOD,
                                                  _CYHAL_LPTIMER_MAX_COMPARE);
-            #endif /* defined (TARGET_STM32U5xx) */
+            #endif /* defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx) */
 
 
             /* Register Autoreload match callback */
@@ -456,7 +456,7 @@ cy_rslt_t cyhal_lptimer_init(cyhal_lptimer_t* obj)
                                              &_cyhal_lptimer_autoreload_match_callback);
 
             /* Enable Autoreload match interrupt enable */
-            #if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx)
+            #if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx)
             __HAL_LPTIM_CLEAR_FLAG(obj->hlptimer, _CYHAL_LPTIM_FLAG_DIEROK);
             __HAL_LPTIM_ENABLE_IT(obj->hlptimer, _CYHAL_LPTIM_IER_ARRMIE);
             while (!__HAL_LPTIM_GET_FLAG(obj->hlptimer, _CYHAL_LPTIM_FLAG_DIEROK))
@@ -465,7 +465,7 @@ cy_rslt_t cyhal_lptimer_init(cyhal_lptimer_t* obj)
             }
             #else
             __HAL_LPTIM_ENABLE_IT(obj->hlptimer, _CYHAL_LPTIM_IER_ARRMIE);
-            #endif /* defined (TARGET_STM32U5xx) */
+            #endif /* defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx) */
 
 
             rslt = (hal_ret == HAL_OK) ? CY_RSLT_SUCCESS : CY_RSLT_TYPE_ERROR;

--- a/Middlewares/Third_Party/pal/targets/TARGET_STM32/Src/stm32_cyhal_sdio.c
+++ b/Middlewares/Third_Party/pal/targets/TARGET_STM32/Src/stm32_cyhal_sdio.c
@@ -467,7 +467,7 @@ cy_rslt_t cyhal_sdio_bulk_transfer(cyhal_sdio_t* obj, cyhal_sdio_transfer_type_t
             /* DMA configuration (use single buffer) */
             obj->hsd->Instance->IDMACTRL  = SDMMC_ENABLE_IDMA_SINGLE_BUFF;
 
-            #if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx)
+            #if defined (TARGET_STM32U5xx) || defined (TARGET_STM32H5xx) || defined (TARGET_STM32H7RSxx)
             obj->hsd->Instance->IDMABASER = (uint32_t)p_dma_buffer;
             #else
             obj->hsd->Instance->IDMABASE0 = (uint32_t)p_dma_buffer;


### PR DESCRIPTION
Added support for the STM32H7RSxx family. Verified with STM32H7S7L8H6H and CYW4373 using NetXDuo.

Hardware:
	ST Microelectronics STM32H7S78-DK (MCU dev kit)
	Embedded Artists EAR00388 (CYW4373 via Murata 2AE, LBEE5PK2AE-564)
	Murata LBEE0ZZ2WE-uSD-M2 (MicroSD adapter board)

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Add support for the STM32H7RSxx Family as it is not compatible with the STM32H7 family.

Related Issue
Issue #22

Context
STM32H7S78-DK (STM32H7S7L8H6H)
Embedded Artists EAR00388 (Murata 2AE, CYW4373)
Keil uVision MDK Pro V5.41.0.0
STM32CubeMx version 6.12.0
